### PR TITLE
Calendar & DateRangePicker 버그 수정

### DIFF
--- a/src/components/Calendar/Calendar.style.ts
+++ b/src/components/Calendar/Calendar.style.ts
@@ -32,7 +32,7 @@ export const dayOfWeekContainerStyling = css({
 
     cursor: 'default',
 
-    '&:hover': {
+    '& span:hover': {
       backgroundColor: Theme.color.white,
     },
   },


### PR DESCRIPTION
<img width="325" alt="Screenshot 2023-07-12 at 5 24 25 PM" src="https://github.com/hang-log-design-system/design-system/assets/51967731/cfc20cc8-4df0-410c-8a3b-e857d37d6f68">

요일을 hover 했을 때 배경색이 변하지 않는다. 

close #30 