### PR TITLE
svg 업로드 버그 관련 웹팩 수정

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,6 @@ module.exports = {
 
   module: {
     rules: [
-      // { test: /\.(png|jpg|svg)$/i, issuer: /\.ts$/, use: 'url-loader' },
       {
         test: /\.(js|jsx|ts|tsx)$/,
         exclude: /node_modules/,
@@ -20,12 +19,12 @@ module.exports = {
       },
       {
         test: /\.svg$/i,
-        issuer: /\.[jt]sx$/,
+        issuer: /\.[jt]sx?$/,
         use: ['@svgr/webpack'],
       },
       {
         test: /\.svg$/i,
-        issuer: /\.(js|ts)$/,
+        issuer: /\.style.js|style.ts$/,
         use: ['url-loader'],
       },
     ],


### PR DESCRIPTION
svg 이미지 사용할 때 url-loader의 issuer를 `js | ts`으로 제한하는 대신 `style.ts | style.js`로 제한.

<br>

close #32 