### PR TITLE
DateRangePicker 버그 수정

### DIFF
--- a/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.tsx
@@ -1,7 +1,7 @@
 import LeftIcon from '@assets/svg/left-icon.svg';
 import RightIcon from '@assets/svg/right-icon.svg';
 import { CALENDAR_MONTH_CHANGE, DEFAULT_MAX_DATE_RANGE } from '@constants/index';
-import type { YearMonth } from '@type/date';
+import type { SelectedDateRange, YearMonth } from '@type/date';
 
 import { formatDate } from '@utils/date';
 
@@ -20,6 +20,8 @@ export interface DateRangePickerProps {
   hasRangeRestriction?: boolean;
   /** 최대로 선택할 수 있는 날짜 범위 */
   maxDateRange?: number;
+  /** 현재 선택된 날짜 범위 */
+  initialSelectedDateRange?: SelectedDateRange;
   /** 날짜를 선택했을 때 실행할 함수 */
   onDateSelect?: CallableFunction;
 }
@@ -28,10 +30,11 @@ const DateRangePicker = ({
   isFutureDaysRestricted = false,
   hasRangeRestriction = false,
   maxDateRange = DEFAULT_MAX_DATE_RANGE,
+  initialSelectedDateRange,
   onDateSelect,
 }: DateRangePickerProps) => {
   const { currentDate, calendarData, handleMonthChange, selectedDateRange, handleDateSelect } =
-    useDateRangePicker();
+    useDateRangePicker(initialSelectedDateRange);
 
   const handleDateClick = (date: number, yearMonth: YearMonth) => () => {
     const clickedDate = formatDate(yearMonth.year, yearMonth.month, date);

--- a/src/hooks/useDateRangePicker.ts
+++ b/src/hooks/useDateRangePicker.ts
@@ -2,11 +2,14 @@ import { CALENDAR_MONTH_CHANGE } from '@constants/index';
 import type { DateRangePickerCalendar, SelectedDateRange, YearMonth } from '@type/date';
 import { useState } from 'react';
 
-import { getNewYearMonthInfo, getYearMonthInfo } from '@utils/date';
+import { getNewYearMonthInfo, getYearMonthInfo, toDate } from '@utils/date';
 
-export const useDateRangePicker = () => {
+export const useDateRangePicker = (initialSelectedDateRange?: SelectedDateRange) => {
   const currentDate = new Date();
-  const currentMonthYearDetail = getYearMonthInfo(currentDate);
+  const initialDate = initialSelectedDateRange
+    ? toDate(initialSelectedDateRange.start!)
+    : currentDate;
+  const currentMonthYearDetail = getYearMonthInfo(initialDate);
 
   const [calendarData, setCalendarData] = useState<DateRangePickerCalendar>({
     prevYearMonth: getNewYearMonthInfo(
@@ -16,10 +19,12 @@ export const useDateRangePicker = () => {
     currentYearMonth: currentMonthYearDetail,
   });
 
-  const [selectedDateRange, setSelectedDateRange] = useState<SelectedDateRange>({
-    start: null,
-    end: null,
-  });
+  const [selectedDateRange, setSelectedDateRange] = useState<SelectedDateRange>(
+    initialSelectedDateRange ?? {
+      start: null,
+      end: null,
+    }
+  );
 
   const handleMonthChange = (change: number) => () => {
     setCalendarData((prevCalendarData) => {

--- a/src/stories/DateRangePicker.stories.tsx
+++ b/src/stories/DateRangePicker.stories.tsx
@@ -28,3 +28,12 @@ export const DaysDisabled: Story = {
     maxDateRange: DEFAULT_MAX_DATE_RANGE,
   },
 };
+
+export const InitialSelectedDateRange = {
+  args: {
+    initialSelectedDateRange: {
+      start: '2023-07-12',
+      end: '2023-07-30',
+    },
+  },
+};


### PR DESCRIPTION
<img width="668" alt="Screenshot 2023-07-14 at 9 47 27 AM" src="https://github.com/hang-log-design-system/design-system/assets/51967731/ef96dc40-cf96-4b3c-b71a-a224b132b1bb">

- DateRangePicker에 초기 날짜 범위 값을 옵셔널로 넘길 수 있다
- 초기 날짜 범위 값이 있는 경우 날짜 범위 시작 지점으로 달력이 포커싱된다


