### PR TITLE
Tabs, ToggleGroup 컴포넌트 수정

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -4,9 +4,9 @@ import { getTabsContainerStyling } from '@components/Tabs/Tabs.style';
 
 export type TabsProps = ComponentPropsWithRef<'div'>;
 
-const Tabs = ({ children }: TabsProps, ref: ForwardedRef<HTMLDivElement>) => {
+const Tabs = ({ children, ...attributes }: TabsProps, ref: ForwardedRef<HTMLDivElement>) => {
   return (
-    <div css={getTabsContainerStyling} ref={ref}>
+    <div css={getTabsContainerStyling} ref={ref} {...attributes}>
       {children}
     </div>
   );

--- a/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/src/components/ToggleGroup/ToggleGroup.tsx
@@ -4,9 +4,12 @@ import { ToggleGroupContainerStyling } from '@components/ToggleGroup/ToggleGroup
 
 export interface ToggleGroupProps extends ComponentPropsWithRef<'div'> {}
 
-const ToggleGroup = ({ children }: ToggleGroupProps, ref: ForwardedRef<HTMLDivElement>) => {
+const ToggleGroup = (
+  { children, ...attributes }: ToggleGroupProps,
+  ref: ForwardedRef<HTMLDivElement>
+) => {
   return (
-    <div css={ToggleGroupContainerStyling} ref={ref}>
+    <div css={ToggleGroupContainerStyling} ref={ref} {...attributes}>
       {children}
     </div>
   );


### PR DESCRIPTION
- Tabs, ToggleGroup에서 div의 attributes를 사용할 수 있어야 한다

close #64 