### PR TITLE
Menu 컴포넌트 버그 수정

### DIFF
--- a/src/components/MenuItem/MenuItem.style.ts
+++ b/src/components/MenuItem/MenuItem.style.ts
@@ -13,6 +13,6 @@ export const menuItemStyling = css({
   cursor: 'pointer',
 
   '&:hover': {
-    backgroundColor: Theme.color.gray200,
+    backgroundColor: Theme.color.gray100,
   },
 });

--- a/src/components/MenuList/MenuList.style.ts
+++ b/src/components/MenuList/MenuList.style.ts
@@ -15,8 +15,9 @@ export const menuListStyling = css({
   marginTop: Theme.spacer.spacing2,
 
   backgroundColor: Theme.color.white,
-  border: `1px solid ${Theme.color.gray200}`,
   borderRadius: Theme.borderRadius.small,
+
+  boxShadow: Theme.boxShadow.shadow8,
 
   transition: 'all .2 ease-in',
 });


### PR DESCRIPTION
- Menu가 열렸을 때 container에 border가 아닌 box-shadow가 생겨야 한다. 
- MenuItem을 hover 했을 때 backgroundColor가 gray200이 아닌 gray100으로 변경.

<br />

close #101 