### PR TITLE
Layout 컴포넌트들 수정

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,16 +1,25 @@
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef, ElementType } from 'react';
 
 import { BoxStylingProps, getBoxStyling } from '@components/Box/Box.style';
 
 export interface BoxProps extends ComponentPropsWithoutRef<'div'> {
+  /**
+   * Box 컴포넌트가 사용할 HTML 태그
+   *
+   * @default 'div'
+   */
+  tag?: ElementType;
+  /** Box 컴포넌트 스타일 옵션 */
   styles?: BoxStylingProps;
 }
 
-const Box = ({ styles = {}, children, ...attributes }: BoxProps) => {
+const Box = ({ tag = 'div', styles = {}, children, ...attributes }: BoxProps) => {
+  const Tag = tag;
+
   return (
-    <div css={getBoxStyling(styles)} {...attributes}>
+    <Tag css={getBoxStyling(styles)} {...attributes}>
       {children}
-    </div>
+    </Tag>
   );
 };
 

--- a/src/components/Center/Center.tsx
+++ b/src/components/Center/Center.tsx
@@ -1,14 +1,23 @@
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef, ElementType } from 'react';
 
 import { getCenterStyling } from '@components/Center/Center.style';
 
-type CenterPorps = ComponentPropsWithoutRef<'div'>;
+interface CenterProps extends ComponentPropsWithoutRef<'div'> {
+  /**
+   * Center 컴포넌트가 사용할 HTML 태그
+   *
+   * @default 'div'
+   */
+  tag?: ElementType;
+}
 
-const Center = ({ children, ...attributes }: CenterPorps) => {
+const Center = ({ tag = 'div', children, ...attributes }: CenterProps) => {
+  const Tag = tag;
+
   return (
-    <div css={getCenterStyling} {...attributes}>
+    <Tag css={getCenterStyling} {...attributes}>
       {children}
-    </div>
+    </Tag>
   );
 };
 

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -1,16 +1,25 @@
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef, ElementType } from 'react';
 
 import { FlexStylingProps, getFlexStyling } from '@components/Flex/Flex.style';
 
-export interface FlexPorps extends ComponentPropsWithoutRef<'div'> {
+export interface FlexProps extends ComponentPropsWithoutRef<'div'> {
+  /**
+   * Flex 컴포넌트가 사용할 HTML 태그
+   *
+   * @default 'div'
+   */
+  tag?: ElementType;
+  /** Flex 컴포넌트 스타일 옵션 */
   styles?: FlexStylingProps;
 }
 
-const Flex = ({ styles = {}, children, ...attributes }: FlexPorps) => {
+const Flex = ({ tag = 'div', styles = {}, children, ...attributes }: FlexProps) => {
+  const Tag = tag;
+
   return (
-    <div css={getFlexStyling(styles)} {...attributes}>
+    <Tag css={getFlexStyling(styles)} {...attributes}>
       {children}
-    </div>
+    </Tag>
   );
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,14 @@
 export type Size = 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge' | 'xxLarge';
+
+type AnyComponent = React.ComponentType<any>;
+type KnownTarget = keyof JSX.IntrinsicElements | AnyComponent;
+type StyledTarget<R> = R extends keyof JSX.IntrinsicElements ? R : AnyComponent;
+type Runtime = keyof JSX.IntrinsicElements | AnyComponent;
+
+export type PolymorphicComponentProps<
+  R extends Runtime,
+  E extends StyledTarget<R>,
+  P extends object
+> = {
+  as?: P extends { as?: infer As } ? As : E;
+};


### PR DESCRIPTION
- Flex, Box, Center 컴포넌트들이 props로 사용할 태그(ex. ul, section, etc.)를 받을 수 있도록 한다.

<br>

```tsx
  /**
   * 컴포넌트가 사용할 HTML 태그
   *
   * @default 'div'
   */
  tag?: ElementType;
```